### PR TITLE
[2.0.0]: Remove deprecated refs and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ You can also optionally supply your own regular expressions to determine what de
 If you wish to add interactivity to your Karaoke (Similar to Spotify), then you can use the `onSeekTo` prop which exposes `onPress` events from individual chunks.
 
 ```tsx
+const transcript = `
+  [00:00:03] Tell me something I need to know
+  [00:00:07] Then take my breath and never let it go
+  [00:00:12] If you just let me invade your space
+  [00:00:17] I'll take the pleasure, take it with the pain
+  [00:00:22] And if in the moment, I bite my lip
+  [00:00:27] Baby, in that moment, you'll know this is
+  [00:00:32] Something bigger than us and beyond bliss
+  [00:00:37] Give me a reason to believe it
+`
+
 <Karaoke
   transcript={transcript}
   progress={progress}

--- a/example/package.json
+++ b/example/package.json
@@ -16,7 +16,7 @@
     "react": "18.0.0",
     "react-dom": "18.0.0",
     "react-native": "0.69.6",
-    "react-native-transcript-karaoke": "^1.0.0",
+    "react-native-transcript-karaoke": "^2.0.0",
     "react-native-web": "~0.18.7"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-transcript-karaoke",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-transcript-karaoke",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react-native": "^0.70.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "MIT",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "name": "react-native-transcript-karaoke",
   "description": "Karaoke-style transcript manipulation for react native",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,4 @@
-import { Karaoke } from './components/Karaoke'
-
 export * from './models/progress-type'
 export * from './models/karaoke-props'
 export * from './utils/as-karaoke-map'
-export { Karaoke } from './components/Karaoke'
-
-const TranscriptKaraoke = Karaoke
-
-/**
- * @deprecated Please use the new nomenclature: `import { Karaoke } from 'react-native-transcript-karaoke'`
- */
-export default TranscriptKaraoke
+export * from './components/Karaoke'


### PR DESCRIPTION
- Remove old `TranscriptKaraoke` reference
- Update documentation to show an example of a transcript